### PR TITLE
Integration tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "PORT=3000 node src/server/server.js",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "test:integration": "PORT=3030 node test/integration/login-flow.spec.js"
+    "test:integration": "PORT=3030 node test/integration/runner.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "src/server/server.js",
   "scripts": {
     "start": "PORT=3000 node src/server/server.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "test:integration": "PORT=3030 node test/integration/login-flow.spec.js"
   },
   "repository": {
     "type": "git",

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -80,3 +80,8 @@ const broadcast = (message, exclude = []) => {
 		client.send(data)
 	})
 }
+
+process.on('SIGTERM', () => {
+	console.log('Bye.')
+	process.exit(0)
+})

--- a/test/integration/fixtures.js
+++ b/test/integration/fixtures.js
@@ -1,0 +1,4 @@
+module.exports.login = nickname => JSON.stringify({
+	type: 'login',
+	payload: { nickname },
+})

--- a/test/integration/login-flow.spec.js
+++ b/test/integration/login-flow.spec.js
@@ -1,13 +1,23 @@
+'use strict'
+
 const assert = require('assert')
 const { fork } = require('child_process')
 const path = require('path')
+
+const {
+	delay,
+	tryCatch,
+	zip,
+} = require('./utils')
+
+const { login } = require('./fixtures')
 
 const WebSocket = require('ws')
 
 const { PORT } = process.env
 
 
-const test = (description, fn) =>
+const test = (description, fn) => () =>
 	Promise.resolve()
 		.then(fn)
 		.then(() => {
@@ -18,10 +28,6 @@ const test = (description, fn) =>
 			console.log(error)
 			console.log('\x1b[0m')
 		})
-
-const delay = ms => data => new Promise(resolve => {
-	setTimeout(() => resolve(data), ms)
-})
 
 const TEST_TIMEOUT = 2000
 
@@ -41,48 +47,47 @@ const main = () => {
 		})
 }
 
-const testWs = (description, fn) =>
-	test(description, () => new Promise((resolve, reject) => {
-		const ws = new WebSocket(`ws://localhost:${PORT}`)
-		ws.onopen = () => {
-			fn(ws)
-				.then(resolve)
-				.catch(reject)
-		}
-		ws.onerror = error => {
-			ws.close()
-			reject(error)
-		}
-	}))
-
 const openConnection = () => new Promise((resolve, reject) => {
 	const ws = new WebSocket(`ws://localhost:${PORT}`)
 	ws.onopen = () => {
 		resolve(ws)
 	}
 	ws.onerror = error => {
+		ws.close()
 		reject(error)
 	}
 })
 
-const assertLogin = nickname =>
-	openConnection()
+const runConnection = (messages, timeout = TEST_TIMEOUT) => {
+	const messagesList = Array.isArray(messages)
+		? messages
+		: [ messages ]
+	return openConnection()
 		.then(ws => new Promise((resolve, reject) => {
-			const timeout = setTimeout(() => {
-				reject(`No message received after ${TEST_TIMEOUT} ms`)
-			}, TEST_TIMEOUT)
-			ws.onmessage = event => {
-				clearTimeout(timeout)
-				const { type, payload } = JSON.parse(event.data)
-				assert.strictEqual(type, 'login-response')
-				assert.deepEqual(payload, { nickname })
+			const received = []
+			setTimeout(() => {
 				ws.close()
-				resolve(ws)
+				resolve(received)
+			}, timeout)
+			ws.onmessage = event => {
+				received.push(JSON.parse(event.data))
 			}
-			ws.send(login(nickname))
+			ws.onerror = reject
+			messagesList.forEach(m => {
+				ws.send(m)
+			})
 		}))
+}
 
-const runTests = () => Promise.all([
+const runSerial = tests =>
+	tests.reduce(
+		(prev, t) => prev
+			.then(t)
+			.catch(t),
+		Promise.resolve()
+	)
+
+const runTests = () => runSerial([
 	test('A new player can login', () =>
 		new Promise((resolve, reject) => {
 			const ws = new WebSocket(`ws://localhost:${PORT}`)
@@ -92,12 +97,20 @@ const runTests = () => Promise.all([
 			}
 			ws.onmessage = event => {
 				const { type, payload } = JSON.parse(event.data)
-				assert.strictEqual(type, 'login-response')
-				assert.deepEqual(payload, {
-					nickname: 'Fluttershy',
+				// This needs to be done because `assert.*` functions throw errors
+				// when something is not equal, but since this a callback sent to ws.onmessage
+				// the exception will not be wrapped normally within the promise.
+				tryCatch(() => {
+					assert.strictEqual(type, 'login-response')
+					assert.deepEqual(payload, {
+						nickname: 'Fluttershy',
+					})
 				})
-				ws.close()
-				resolve()
+				.then(() => {
+					ws.close()
+					resolve()
+				})
+				.catch(reject)
 			}
 			ws.onclose = () => {
 				console.log('Connection terminated')
@@ -109,20 +122,21 @@ const runTests = () => Promise.all([
 		})
 	),
 	test('Two players can login', () =>
-		Promise.all([
-			assertLogin('Fluttershy'),
-			Promise.resolve('Rainbow Dash')
-				.then(delay(200))
-				.then(assertLogin),
-		])
+		Promise
+			.all([
+				runConnection(login('Fluttershy'), 500),
+				runConnection(login('Rainbow Dash'), 500),
+			])
+			.then(players => {
+				zip([ 'Fluttershy', 'Rainbow Dash' ], players)
+					.forEach(([ nickname, events ]) => {
+						const event = events.find(({ type }) => type === 'login-response')	
+						assert.ok(event != null)
+						assert.deepEqual(event.payload, { nickname })
+					})
+			})
 	),
 ])
 
 main()
 
-// Messages
-
-const login = nickname => JSON.stringify({
-	type: 'login',
-	payload: { nickname },
-})

--- a/test/integration/login-flow.spec.js
+++ b/test/integration/login-flow.spec.js
@@ -1,0 +1,128 @@
+const assert = require('assert')
+const { fork } = require('child_process')
+const path = require('path')
+
+const WebSocket = require('ws')
+
+const { PORT } = process.env
+
+
+const test = (description, fn) =>
+	Promise.resolve()
+		.then(fn)
+		.then(() => {
+			console.log(`\n\x1b[32m * OK   - ${description}\x1b[0m`)
+		})
+		.catch(error => {
+			console.log(`\n\x1b[31m * FAIL - ${description}`)
+			console.log(error)
+			console.log('\x1b[0m')
+		})
+
+const delay = ms => data => new Promise(resolve => {
+	setTimeout(() => resolve(data), ms)
+})
+
+const TEST_TIMEOUT = 2000
+
+const main = () => {
+	const server = fork(path.resolve(__dirname, '..', '..', 'src', 'server', 'server.js'), [], {
+		detached: true,
+		env: { PORT },
+	})
+	server.on('error', error => {
+		console.log('Error', error)
+		server.kill()
+	})
+	delay(500) ()
+		.then(runTests)
+		.then(() => {
+			server.kill()
+		})
+}
+
+const testWs = (description, fn) =>
+	test(description, () => new Promise((resolve, reject) => {
+		const ws = new WebSocket(`ws://localhost:${PORT}`)
+		ws.onopen = () => {
+			fn(ws)
+				.then(resolve)
+				.catch(reject)
+		}
+		ws.onerror = error => {
+			ws.close()
+			reject(error)
+		}
+	}))
+
+const openConnection = () => new Promise((resolve, reject) => {
+	const ws = new WebSocket(`ws://localhost:${PORT}`)
+	ws.onopen = () => {
+		resolve(ws)
+	}
+	ws.onerror = error => {
+		reject(error)
+	}
+})
+
+const assertLogin = nickname =>
+	openConnection()
+		.then(ws => new Promise((resolve, reject) => {
+			const timeout = setTimeout(() => {
+				reject(`No message received after ${TEST_TIMEOUT} ms`)
+			}, TEST_TIMEOUT)
+			ws.onmessage = event => {
+				clearTimeout(timeout)
+				const { type, payload } = JSON.parse(event.data)
+				assert.strictEqual(type, 'login-response')
+				assert.deepEqual(payload, { nickname })
+				ws.close()
+				resolve(ws)
+			}
+			ws.send(login(nickname))
+		}))
+
+const runTests = () => Promise.all([
+	test('A new player can login', () =>
+		new Promise((resolve, reject) => {
+			const ws = new WebSocket(`ws://localhost:${PORT}`)
+			ws.onopen = () => {
+				console.log('Connected to server')
+				ws.send(login('Fluttershy'))
+			}
+			ws.onmessage = event => {
+				const { type, payload } = JSON.parse(event.data)
+				assert.strictEqual(type, 'login-response')
+				assert.deepEqual(payload, {
+					nickname: 'Fluttershy',
+				})
+				ws.close()
+				resolve()
+			}
+			ws.onclose = () => {
+				console.log('Connection terminated')
+			}
+			ws.onerror = error => {
+				ws.close()
+				reject(error)
+			}
+		})
+	),
+	test('Two players can login', () =>
+		Promise.all([
+			assertLogin('Fluttershy'),
+			Promise.resolve('Rainbow Dash')
+				.then(delay(200))
+				.then(assertLogin),
+		])
+	),
+])
+
+main()
+
+// Messages
+
+const login = nickname => JSON.stringify({
+	type: 'login',
+	payload: { nickname },
+})

--- a/test/integration/runner.js
+++ b/test/integration/runner.js
@@ -1,0 +1,4 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')

--- a/test/integration/runner.js
+++ b/test/integration/runner.js
@@ -1,4 +1,60 @@
 'use strict'
 
+const { execFileSync } = require('child_process')
 const fs = require('fs')
 const path = require('path')
+const { promisify } = require('util')
+
+const { exists } = require('./utils')
+
+const readDir = promisify(fs.readdir)
+
+
+const [ FILE ] = process.argv.slice(2)
+
+const SPECS_FOLDER = path.resolve(__dirname, 'specs')
+
+
+const main = () => generateFileList(FILE)
+	.then(runTestSuites)
+	.catch(error => {
+		console.error(error)
+		process.exit(1)
+	})
+
+
+// generateFileList
+
+const generateFileList = file =>
+	exists(file)
+		? Promise.resolve([ file ])
+		: readDir(SPECS_FOLDER)
+			.then(filterSpecFiles)
+			.then(prependDir(SPECS_FOLDER))
+
+const filterSpecFiles = files =>
+	files.filter(x =>
+		x.match(/\.(spec|test).js$/)
+	)
+
+const prependDir = dir => files =>
+	files.map(x =>
+		path.join(dir, x)
+	)
+
+
+// runTestSuites
+
+const runTestSuites = files => {
+	files.forEach(file => {
+		console.log(`\n> Running test suite ${file}\n`)
+		const output = execFileSync('node', [ file ], {
+			env: process.env,
+		})
+		console.log(output.toString())
+	})
+	return Promise.resolve()
+}
+
+
+main()

--- a/test/integration/runtime.js
+++ b/test/integration/runtime.js
@@ -1,0 +1,75 @@
+'use strict'
+
+const { fork } = require('child_process')
+const path = require('path')
+
+const { delay } = require('./utils')
+
+const DEFAULT_TIMEOUT = 5000
+
+
+const runWithTimeout = (fn, timeout) =>
+	new Promise((resolve, reject) => {
+		const t = setTimeout(() => {
+			// TODO: this should cancel the running test as well.
+			reject(`Test didn't finish after ${timeout} ms`)
+		}, timeout)
+		fn()
+			.then(data => {
+				clearTimeout(t)
+				resolve(data)
+			})
+	})
+
+const makeSuite = (description, fn) => {
+	const cases = []
+
+	const test = (description, fn) => {
+		const run = () => runWithTimeout(fn, DEFAULT_TIMEOUT)
+			.then(fn)
+			.then(() => {
+				console.log(`\n\x1b[32m * OK   - ${description}\x1b[0m`)
+			})
+			.catch(error => {
+				console.log(`\n\x1b[31m * FAIL - ${description}`)
+				console.log(error)
+				console.log('\x1b[0m')
+			})
+		cases.push(run)
+	}
+
+	const runSerial = () => {
+		console.log(description)
+		return cases.reduce(
+			(prev, t) => prev
+				.then(t)
+				.catch(t),
+			Promise.resolve()
+		)
+	}
+
+	const runWithServer = (PORT) => {
+		const server = fork(path.resolve(__dirname, '..', '..', 'src', 'server', 'server.js'), [], {
+			detached: true,
+			env: { PORT },
+		})
+		server.on('error', error => {
+			console.log('Error', error)
+			server.kill()
+		})
+		delay(500)()
+			.then(runSerial)
+			.then(() => {
+				server.kill()
+			})
+	}
+	
+	fn(test)
+	
+	return {
+		runSerial,
+		runWithServer,
+	}
+}
+
+module.exports = makeSuite

--- a/test/integration/specs/login-flow.spec.js
+++ b/test/integration/specs/login-flow.spec.js
@@ -6,46 +6,12 @@ const { zip } = require('../utils')
 const suite = require('../runtime')
 const { login } = require('../fixtures')
 
-const WebSocket = require('ws')
-
 const { PORT } = process.env
 
 
-const openConnection = () => new Promise((resolve, reject) => {
-	const ws = new WebSocket(`ws://localhost:${PORT}`)
-	ws.onopen = () => {
-		resolve(ws)
-	}
-	ws.onerror = error => {
-		ws.close()
-		reject(error)
-	}
-})
-
-const runConnection = (messages, timeout = 500) => {
-	const messagesList = Array.isArray(messages)
-		? messages
-		: [messages]
-	return openConnection()
-		.then(ws => new Promise((resolve, reject) => {
-			const received = []
-			setTimeout(() => {
-				ws.close()
-				resolve(received)
-			}, timeout)
-			ws.onmessage = event => {
-				received.push(JSON.parse(event.data))
-			}
-			ws.onerror = reject
-			messagesList.forEach(m => {
-				ws.send(m)
-			})
-		}))
-}
-
 suite('Login flow', test => {
-	test('A new player can login', () =>
-		runConnection(login('Fluttershy'), 500)
+	test('A new player can login', t =>
+		t.run(login('Fluttershy'), 500)
 			.then(events => {
 				assert.deepEqual(events, [{
 					type: 'login-response',
@@ -56,11 +22,11 @@ suite('Login flow', test => {
 			})
 	)
 
-	test('Two players can login', () =>
+	test('Two players can login', t =>
 		Promise
 			.all([
-				runConnection(login('Fluttershy'), 500),
-				runConnection(login('Rainbow Dash'), 500),
+				t.run(login('Fluttershy'), 500),
+				t.run(login('Rainbow Dash'), 500),
 			])
 			.then(players => {
 				zip(['Fluttershy', 'Rainbow Dash'], players)

--- a/test/integration/specs/login-flow.spec.js
+++ b/test/integration/specs/login-flow.spec.js
@@ -2,9 +2,9 @@
 
 const assert = require('assert')
 
-const { zip } = require('./utils')
-const suite = require('./runtime')
-const { login } = require('./fixtures')
+const { zip } = require('../utils')
+const suite = require('../runtime')
+const { login } = require('../fixtures')
 
 const WebSocket = require('ws')
 

--- a/test/integration/utils.js
+++ b/test/integration/utils.js
@@ -1,0 +1,15 @@
+module.exports.delay = ms => data => new Promise(resolve => {
+	setTimeout(() => resolve(data), ms)
+})
+
+module.exports.tryCatch = fn => {
+	try {
+		const result = fn()
+		return Promise.resolve(result)
+	} catch (error) {
+		return Promise.reject(error)
+	}
+}
+
+module.exports.zip = (a, b) =>
+	a.map((x, i) => [x, b[i]])

--- a/test/integration/utils.js
+++ b/test/integration/utils.js
@@ -2,6 +2,8 @@ module.exports.delay = ms => data => new Promise(resolve => {
 	setTimeout(() => resolve(data), ms)
 })
 
+module.exports.exists = value => value != null
+
 module.exports.tryCatch = fn => {
 	try {
 		const result = fn()


### PR DESCRIPTION
Added a small framework to run integration tests plus a couple of tests for the login flow.

The module `runtime` contains the core of the framework. It exports the function `makeSuite` which receives a function that is used to create the test cases. Then it returns two functions:
- `runSerial` simply takes the tests created in the suite and runs them in serial.
- `runWithServer` launches an instance of the game server and passes to each test case a couple of extra functions: `open`, which opens a connection to the server and resolves with the websocket object, and `run`, which opens a connection to the server, sends the messages provided in the first parameter through the websocket, and resolve with the messages received from the server after the timeout provided in the second parameter.

The module `runner` loads the test files and executes them. It can be executed through the shell with a file as optional argument. If the argument is provided, it will only load and execute that file, otherwise it will execute all files found in the directory `test/integration/specs/` with the extensions `.spec.js` and `.test.js`.